### PR TITLE
feat: implemented backup flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+.venv

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 ## Testing
 
 ```sh
+python test_dataset_backup.py "<project>" "<dataset-id>" "<location>" "<bucket_name>"
+```
+
+```sh
 python test_clean_dataset.py "<project>" "<source-dataset>" "<destination-dataset>" "<destination-table-prefix>"
 ```
 

--- a/flows/dataset_backup_flow.deployment.py
+++ b/flows/dataset_backup_flow.deployment.py
@@ -5,15 +5,15 @@ from prefect.deployments import Deployment
 from prefect.filesystems import GCS
 from prefect.infrastructure.container import DockerContainer
 
-from run_dataform_flow import run_dataform_flow
+from dataset_backup_flow import dataset_backup_flow
 
 
 def deploy(
     env,
     customer_id,
     gcp_credentials_block_name,
-    repository_location,
-    repository_name,
+    dataset_id,
+    bucket_name,
 ):
     assert Path.cwd() == Path(__file__).parent
     gcs_block = GCS.load("qbi-prefect-storage")
@@ -24,8 +24,8 @@ def deploy(
     }[env]
 
     deployment = Deployment.build_from_flow(
-        flow=run_dataform_flow,
-        name=f"{customer_id}-{run_dataform_flow.name}",
+        flow=dataset_backup_flow,
+        name=f"{customer_id}-{dataset_backup_flow.name}",
         storage=gcs_block,
         infrastructure=docker_container_block,
         work_queue_name=work_queue_name,
@@ -33,8 +33,8 @@ def deploy(
         path="prefect-qbi",
         parameters={
             "gcp_credentials_block_name": gcp_credentials_block_name,
-            "repository_location": repository_location,
-            "repository_name": repository_name,
+            "dataset_id": dataset_id,
+            "bucket_name": bucket_name,
         },
     )
     deployment.apply()

--- a/flows/dataset_backup_flow.py
+++ b/flows/dataset_backup_flow.py
@@ -1,0 +1,10 @@
+from prefect import flow
+
+
+@flow
+def dataset_backup_flow(gcp_credentials_block_name, dataset_id, bucket_name):
+    # Import inside the function to prevent error
+    # when `prefect_qbi` is not available during deployment.
+    from prefect_qbi import backup_dataset
+
+    backup_dataset(gcp_credentials_block_name, dataset_id, bucket_name)

--- a/prefect_qbi/__init__.py
+++ b/prefect_qbi/__init__.py
@@ -2,7 +2,27 @@ from google.cloud import dataform_v1beta1
 from prefect import task
 from prefect_gcp import GcpCredentials
 
-from . import clean, dataform
+from . import backup, clean, dataform
+
+
+@task
+def backup_dataset(gcp_credentials_block_name, dataset_id, bucket_name):
+    gcp_credentials_block = GcpCredentials.load(gcp_credentials_block_name)
+    client = gcp_credentials_block.get_bigquery_client()
+    project_id = gcp_credentials_block.project
+    assert project_id, "No project found"
+
+    backup.dataset(client, project_id, dataset_id, bucket_name)
+
+
+@task
+def backup_table(gcp_credentials_block_name, dataset_id, table_id, bucket_name):
+    gcp_credentials_block = GcpCredentials.load(gcp_credentials_block_name)
+    client = gcp_credentials_block.get_bigquery_client()
+    project_id = gcp_credentials_block.project
+    assert project_id, "No project found"
+
+    backup.table(client, project_id, dataset_id, table_id, bucket_name)
 
 
 @task

--- a/prefect_qbi/backup/__init__.py
+++ b/prefect_qbi/backup/__init__.py
@@ -1,0 +1,31 @@
+from google.cloud import bigquery
+
+
+def _extract_table(client, project_id, dataset_id, table_id, location, bucket_name):
+    destination_uri = "gs://{}/{}".format(
+        bucket_name, f"{dataset_id}__{table_id}__backup.csv"
+    )
+
+    dataset_ref = bigquery.DatasetReference(project_id, dataset_id)
+    table_ref = dataset_ref.table(table_id)
+
+    extract_job = client.extract_table(table_ref, destination_uri, location=location)
+    extract_job.result()
+    print(
+        "Exported {}:{}.{} to {}".format(
+            project_id, dataset_id, table_id, destination_uri
+        )
+    )
+
+
+def dataset(client, project_id, dataset_id, location, bucket_name):
+    tables = client.list_tables(dataset_id)
+
+    for table in tables:
+        _extract_table(
+            client, project_id, dataset_id, table.table_id, location, bucket_name
+        )
+
+
+def table(client, project_id, dataset_id, table_id, location, bucket_name):
+    _extract_table(client, project_id, dataset_id, table_id, location, bucket_name)

--- a/test_dataset_backup.py
+++ b/test_dataset_backup.py
@@ -1,0 +1,21 @@
+import sys
+
+from google.cloud import bigquery
+
+from prefect_qbi.backup import dataset
+
+
+def test_dataset_backup(project_id, dataset_id, location, bucket_name):
+    client = bigquery.Client(project=project_id)
+    dataset(
+        client,
+        project_id,
+        dataset_id,
+        location,
+        bucket_name,
+    )
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    test_dataset_backup(*args)


### PR DESCRIPTION
Added two new flows:

- `backup_dataset` backs up an entire dataset from a project i.e. all tables. 
- `backup_table` is the same as above, but only one table is exported

Also added the possibility to test the dataset backup flow with `test_dataset_backup.py` script. I decided not to include a separate script for tables, since the flows are essentially only different by one of them having a for loop.